### PR TITLE
Removed k8soidc:jwks_uri key in k2hr3-api-production.json.templ

### DIFF
--- a/src/libexec/database-k8s/k2hr3-api-production.json.templ
+++ b/src/libexec/database-k8s/k2hr3-api-production.json.templ
@@ -75,7 +75,6 @@
 	'k8soidc': {
 		'audience':		'%%OIDC_CLIENT_ID%%',
 		'issuer':		'%%OIDC_ISSUER_URL%%',
-		'jwks_uri':		'%%OIDC_ISSUER_URL%%/keys',
 		'usernamekey':	'%%OIDC_USERNAME_KEY%%',
 		'k8sapi_url':	'%%K8S_API_URL%%',
 		'k8s_ca_path':	'%%K8S_CA_CERT%%',


### PR DESCRIPTION
## Relevant Issue (if applicable)
https://github.com/yahoojapan/k2hr3_api/pull/53 

## Details
Remove the `jwks_uri` key from the template as it is no longer needed in the OIDC settings of the K2HR3 API.

