### PR TITLE
Using RockyLinux:8 instead of CentOS:8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           - ubuntu:16.04
           - debian:buster
           - debian:stretch
-          - centos:centos8
+          - rockylinux:8
           - centos:centos7
           - fedora:32
           - fedora:31

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -134,7 +134,7 @@ elif [ "X${CI_OSTYPE}" = "Xdebian:9" ] || [ "X${CI_OSTYPE}" = "Xdebian:stretch" 
 	PKG_EXT="deb"
 	IS_OS_DEBIAN=1
 
-elif [ "X${CI_OSTYPE}" = "Xcentos:8" ] || [ "X${CI_OSTYPE}" = "Xcentos:centos8" ]; then
+elif [ "X${CI_OSTYPE}" = "Xcentos:8" ] || [ "X${CI_OSTYPE}" = "Xcentos:centos8" ] || [ "X${CI_OSTYPE}" = "Xrockylinux:8" ]; then
 	DIST_TAG="el/8"
 	INSTALL_PKG_LIST="git autoconf automake gcc-c++ make pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps"
 	CONFIGURE_EXT_OPT=""


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Changed container image to RockyLinux:8 instead of CentOS:8, because CentOS:8 is not supported any more.

