### PR TITLE
Updated ChangeLog for v1.0.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+k2hdkc-dbaas-k8s-cli (1.0.3) trusty; urgency=low
+
+  * Stabilized the startup of the k2hdkc cluster in k2hr3 - #7
+  * Using RockyLinux:8 instead of CentOS:8 - #6
+  * Fixed a bug in dbaas-k2hdkc-chmpxproc-wrap.sh - #5
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Tue, 15 Mar 2022 15:19:52 +0900
+
 k2hdkc-dbaas-k8s-cli (1.0.2) trusty; urgency=low
 
   * Removed k8soidc:jwks_uri key in k2hr3-api-production.json.templ - #3


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.2 to 1.0.3
- Stabilized the startup of the k2hdkc cluster in k2hr3 - #7
- Using RockyLinux:8 instead of CentOS:8 - #6
- Fixed a bug in dbaas-k2hdkc-chmpxproc-wrap.sh - #5

