### PR TITLE
Separated the shellcheck process in the build process

### DIFF
--- a/.github/workflows/build_helper.sh
+++ b/.github/workflows/build_helper.sh
@@ -537,6 +537,12 @@ run_cmd ./autogen.sh
 echo "[INFO] ${PRGNAME} : Build - run configure."
 run_cmd ./configure --prefix=/usr "${CONFIGURE_EXT_OPT}"
 
+echo "[INFO] ${PRGNAME} : Build - run clean."
+run_cmd make clean
+
+echo "[INFO] ${PRGNAME} : Build - run shellcheck."
+run_cmd make shellcheck
+
 echo "[INFO] ${PRGNAME} : Build - run build and shellcheck."
 run_cmd make build
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,9 +44,8 @@ clean-local-files:
 # [BUILD]
 # Since it is a shell script-only project, there is nothing to build,
 # but we will create a VERSION file.
-# Then, shellcheck checks all the source code.
 #
-build: setup_k2hr3_cli build_version shellcheck
+build: setup_k2hr3_cli build_version
 
 .PHONY: setup_k2hr3_cli build_version shellcheck
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Decoupled the shellcheck process from being defined as part of the build process.