### PR TITLE
Updated debian_build.sh for grep parameter and updated configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ AM_INIT_AUTOMAKE()
 #
 # Checks for programs.
 #
+AC_PROG_CXX
 AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_INSTALL


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed the part where the `grep` command parameter was not appropriate.
And added macros to `configure.ac` because they were missing.